### PR TITLE
Changing the master and slave jargon

### DIFF
--- a/LTCCapPython/paramsDialog.py
+++ b/LTCCapPython/paramsDialog.py
@@ -9,51 +9,51 @@ except:
 class ParamsDialog(tkSimpleDialog.Dialog):
     """A dialog to get the hardware parameters"""
     
-    def body(self, master):
+    def body(self, main):
 
         self.wm_iconbitmap('linearIcon.ico')
         self.title('Choose Hardware Parameters')
 
         self.result = False
         
-        self.deviceLabel = Label(master, text='Device')
+        self.deviceLabel = Label(main, text='Device')
         self.deviceLabel.grid(row=0, column=0, columnspan=2, sticky=SW)
-        self.deviceCombo = Combobox(master, ['DC718', 'DC890'], relief=RIDGE, bd=4, textWidth=20)
+        self.deviceCombo = Combobox(main, ['DC718', 'DC890'], relief=RIDGE, bd=4, textWidth=20)
         self.deviceCombo.grid(row=1, column=0, columnspan=2, sticky=NW)
 
-        self.nChannelsLabel = Label(master, text='# Channels')
+        self.nChannelsLabel = Label(main, text='# Channels')
         self.nChannelsLabel.grid(row=2, column=0, columnspan=2, sticky=SW)
         self.nChannelsText  = StringVar()
         self.nChannelsText.set('1')
-        self.nChannelsEntry = Entry(master, textvariable=self.nChannelsText)
+        self.nChannelsEntry = Entry(main, textvariable=self.nChannelsText)
         self.nChannelsEntry.grid(row=3, column=0, columnspan=2, sticky=NW)
 
-        self.nBitsLabel = Label(master, text='# Bits')
+        self.nBitsLabel = Label(main, text='# Bits')
         self.nBitsLabel.grid(row=4, column=0, sticky=SW)
         self.nBitsText  = StringVar()
         self.nBitsText.set('16')
-        self.nBitsEntry = Entry(master, textvariable=self.nBitsText)
+        self.nBitsEntry = Entry(main, textvariable=self.nBitsText)
         self.nBitsEntry.grid(row=5, column=0, sticky=NW, padx=5)
 
-        self.alignmentLabel = Label(master, text='Alignment')
+        self.alignmentLabel = Label(main, text='Alignment')
         self.alignmentLabel.grid(row=4, column=1, sticky=SW)
         self.alignmentText  = StringVar()
         self.alignmentText.set('16')
-        self.alignmentEntry = Entry(master, textvariable=self.alignmentText)
+        self.alignmentEntry = Entry(main, textvariable=self.alignmentText)
         self.alignmentEntry.grid(row=5, column=1, sticky=NW, padx=5)
 
         self.isBipolar = IntVar()
-        self.isBipolarCheck = Checkbutton(master, text='Bipolar', variable=self.isBipolar)
+        self.isBipolarCheck = Checkbutton(main, text='Bipolar', variable=self.isBipolar)
         self.isBipolarCheck.grid(row=0, column=2, rowspan=2, sticky=W)
 
-        self.clockEdgeLabel = Label(master, text='Clock Edge')
+        self.clockEdgeLabel = Label(main, text='Clock Edge')
         self.clockEdgeLabel.grid(row=2, column=2, sticky=SW)
-        self.clockEdgeCombo = Combobox(master, ['POS_EDGE', 'NEG_EDGE'], relief=RIDGE, bd=4, textWidth=20)
+        self.clockEdgeCombo = Combobox(main, ['POS_EDGE', 'NEG_EDGE'], relief=RIDGE, bd=4, textWidth=20)
         self.clockEdgeCombo.grid(row=3, column=2, sticky=NW)
 
-        self.fpgaLoadLabel = Label(master, text='FPGA Load')
+        self.fpgaLoadLabel = Label(main, text='FPGA Load')
         self.fpgaLoadLabel.grid(row=4, column=2, sticky=SW)
-        self.fpgaLoadCombo = Combobox(master, ['NONE', 'CMOS', 'LVDS', 'S1407', 'S1408', \
+        self.fpgaLoadCombo = Combobox(main, ['NONE', 'CMOS', 'LVDS', 'S1407', 'S1408', \
                                                'S2308', 'S2366', 'DCMOS', 'DLVDS'], \
                                       relief=RIDGE, bd=4, textWidth=20)
         self.fpgaLoadCombo.grid(row=5, column=2, sticky=NW)
@@ -70,11 +70,11 @@ class ParamsDialog(tkSimpleDialog.Dialog):
 
 class Combobox(Frame):
     '''A compound widget that lets you type or pick from a drop-down'''
-    def __init__(self, master, entries, textWidth=None, **options):
+    def __init__(self, main, entries, textWidth=None, **options):
     
-        self.master = master
+        self.main = main
     
-        Frame.__init__(self, master, options)
+        Frame.__init__(self, main, options)
         
         # keep track of the items
         self.entries = entries

--- a/LTC_Libs/Drivers/DC590_CLASS.py
+++ b/LTC_Libs/Drivers/DC590_CLASS.py
@@ -37,7 +37,7 @@ class DC590_CLASS(object):
     def __init__(self,timeout=0.1,show_errors=False,baudrate=115200,Linduino=False):
         """DC590 Class Constructor."""
         self.__timeout=timeout                #Communication timeout
-        self.__ack=True                       #I2C slave ack status
+        self.__ack=True                       #I2C subordinate ack status
         self.__count=0                        #The number of DC590's connected
         self.__connected=False                #Serial connection OK
         self.__port_list=[]                   #List of COMM ports with DC590's connected
@@ -379,7 +379,7 @@ class DC590_CLASS(object):
         """SMBUS read result: get the result of an smbus read or write and check for ACK """
         data_string=self.read()                          #read the result from the DC590
         if data_string.find("N")!=-1:                    #check for N (not acknowlege)
-            if self.__show_errors: print "Slave did not acknowledge"
+            if self.__show_errors: print "Subordinate did not acknowledge"
             self.__ack=False
         else:
             self.__ack=True

--- a/modules/spi_avalon_bridge/memory_test.py
+++ b/modules/spi_avalon_bridge/memory_test.py
@@ -333,7 +333,7 @@ try:
                 
                 #print str(failure_detected) + " failure detected variable"
                 bytes_tested = length_counter
-                # The timer only runs while the masters are moving data so 
+                # The timer only runs while the mains are moving data so 
                 # we can read the timer result here                    
                 test_time = RamTestController.read_timer(
                     dc590,

--- a/modules/spi_avalon_bridge/memory_tester_util.py
+++ b/modules/spi_avalon_bridge/memory_tester_util.py
@@ -41,8 +41,8 @@ from ltc_spi_avalon import *
 # Two-To-One MUX
 # ************************************************
 
-# Description:	The component is controlled by a host or master through the 
-#                CSR slave port to control which streaming data input will be 
+# Description:	The component is controlled by a host or main through the 
+#                CSR subordinate port to control which streaming data input will be 
 #                routed to the streaming data output.
 
 # Register map:
@@ -124,8 +124,8 @@ class Mux:
 # One-To-Two DEMUX
 # ************************************************
 
-# Description:	The component is controlled by a host or master through the CSR
-#               slave port to control which streaming data output the input
+# Description:	The component is controlled by a host or main through the CSR
+#               subordinate port to control which streaming data output the input
 #               streaming data will be routed to.
 
 # Register map:
@@ -209,9 +209,9 @@ class Demux:
 # Custom Pattern Checker
 # ************************************************
 
-# Description:  This component is programmed via a host or master through the 
-#               pattern slave port to program the internal test memory.  When 
-#               the host writes to the start bit of the CSR slave port the 
+# Description:  This component is programmed via a host or main through the 
+#               pattern subordinate port to program the internal test memory.  When 
+#               the host writes to the start bit of the CSR subordinate port the 
 #               component will begin to send the contents from the internal 
 #               memory to the data streaming port. You should use the custom 
 #               pattern generator component with this component.
@@ -406,9 +406,9 @@ class Checker:
 # ************************************************
 
 # Description:  
-# This component is programmed via a host or master through the pattern slave 
+# This component is programmed via a host or main through the pattern subordinate 
 # port to program the internal test memory. When the hos writes to the start 
-# bit of the CSR slave port the component will begin to send the contents from 
+# bit of the CSR subordinate port the component will begin to send the contents from 
 # the internal memory to the data streaming port. You should use the custom 
 # pattern checker component with this component.
 
@@ -585,17 +585,17 @@ class Generator:
 #                r/w enable' is set to 0 then the block size represents how much
 #                data will be written before a read verification cycle starts.  
 #                Bits 31-24 are used to specify the block trail. The block trail
-#                represents how many blocks the read master should trail the 
-#                write master by. A block trail of 0 means that the block is 
+#                represents how many blocks the read main should trail the 
+#                write main by. A block trail of 0 means that the block is 
 #                written out and read back immediately. A block train of 1 means
 #                that two blocks will be written followed by reading the first block.
 # Address 16 --> Bit 0 is used to enable concurrent read and write block 
-#                operations. When disabled the read master remains idle while 
-#                the write master operates. When enabled the read and write 
-#                masters can operate concurrently presenting a mix of read and
+#                operations. When disabled the read main remains idle while 
+#                the write main operates. When enabled the read and write 
+#                mains can operate concurrently presenting a mix of read and
 #                write accesses to the memory. Bit 24 is used to start the 
-#                memory test masters and will remain enabled until the last 
-#                read data returns to the read master.
+#                memory test mains and will remain enabled until the last 
+#                read data returns to the read main.
 # Address 20 --> N/A
 # Address 24 --> Timer resolution in terms of system clock cycles. If the 
 #                system clock speed is 100MHz (T=10ns) then setting the 


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.